### PR TITLE
Redis run with Heroku KV add-on

### DIFF
--- a/app/controllers/health_check_controller.rb
+++ b/app/controllers/health_check_controller.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Controller for checking the health status of various application components
 class HealthCheckController < ApplicationController
   def show
     health_status = {
@@ -16,13 +19,13 @@ class HealthCheckController < ApplicationController
 
   def database_check
     ActiveRecord::Base.connection.active? ? "up" : "down"
-  rescue
+  rescue StandardError
     "down"
   end
 
   def redis_check
-    (Redis.new.ping == "PONG") ? "up" : "down"
-  rescue
+    $redis.ping == "PONG" ? "up" : "down"
+  rescue StandardError
     "down"
   end
 end

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -8,9 +8,13 @@ test:
 production:
   adapter: redis
   url: <%= ENV["REDIS_URL"] || ENV["REDISCLOUD_URL"] || "redis://localhost:6379/1" %>
+  ssl_params:
+    verify_mode: <%= OpenSSL::SSL::VERIFY_NONE %>
   channel_prefix: rapid_rails_production
 
 staging:
   adapter: redis
   url: <%= ENV["REDIS_URL"] || ENV["REDISCLOUD_URL"] || "redis://localhost:6379/1" %>
+  ssl_params:
+    verify_mode: <%= OpenSSL::SSL::VERIFY_NONE %>
   channel_prefix: rapid_rails_staging

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Replace the default in-process memory cache store with a durable alternative.
-  config.cache_store = :redis_cache_store, {url: ENV["REDIS_URL"] || ENV["REDISCLOUD_URL"] || "redis://localhost:6379/1"}
+  config.cache_store = :redis_cache_store, {url: REDIS_URL}
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   # config.active_job.queue_adapter = :resque

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,1 +1,6 @@
-$redis = Redis.new(url: ENV["REDIS_URL"] || ENV["REDISCLOUD_URL"], ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE})
+REDIS_URL = ENV["REDIS_URL"] || ENV["REDISCLOUD_URL"] || "redis://localhost:6379/0"
+
+REDIS_CONFIG = {
+  url: REDIS_URL,
+  ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}
+}

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,15 +4,9 @@ if Rails.env.test?
 end
 
 Sidekiq.configure_server do |config|
-  config.redis = {
-    url: ENV["REDIS_URL"] || ENV["REDISCLOUD_URL"],
-    ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}
-  }
+  config.redis = REDIS_CONFIG
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = {
-    url: ENV["REDIS_URL"] || ENV["REDISCLOUD_URL"],
-    ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}
-  }
+  config.redis = REDIS_CONFIG
 end


### PR DESCRIPTION
This pull request includes several changes to improve the handling of Redis configuration and error handling in the `HealthCheckController`.

### Redis Configuration Improvements:
* [`config/initializers/redis.rb`](diffhunk://#diff-6ca0601d8a8ae0e917f92947b7342346054078c985b15d2eddde59f551b2a91eL1-R6): Introduced `REDIS_URL` and `REDIS_CONFIG` constants to centralize Redis configuration.
* [`config/environments/production.rb`](diffhunk://#diff-da60b4e96eff2b132991226d308949e23f4ef3aad45ad59edd09cbc32cc6251eL50-R50): Updated cache store configuration to use the new `REDIS_URL` constant.
* [`config/initializers/sidekiq.rb`](diffhunk://#diff-fe63ad82c410f651197078bd21118c1fa7a9dbb0a468e90940e76ba6c07e87eaL7-R11): Updated Sidekiq configuration to use the new `REDIS_CONFIG` constant.
* [`config/cable.yml`](diffhunk://#diff-661620ae7be69a63f01b319f70bb6e3e0f6183b59258e9ed7aee623d75f17d90R11-R19): Added `ssl_params` to Redis configuration for production and staging environments to disable SSL verification.

### Error Handling Improvements:
* [`app/controllers/health_check_controller.rb`](diffhunk://#diff-74947ecf3548174e272ff336c63f8021a6b09e9af21e0cdfcaae425b706b2110L19-R28): Improved error handling in `database_check` and `redis_check` methods by rescuing `StandardError` instead of a generic rescue.