### PR TITLE
Use discard gem scopes in admin views

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -44,7 +44,7 @@ ActiveAdmin.register_page "Dashboard" do
           "Deleted Users"
         end
         h6 class: "text-2xl font-bold text-gray-900 dark:text-gray-100 mt-2" do
-          User.where.not(discarded_at: nil).count
+          User.discarded.count
         end
       end
     end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -5,10 +5,10 @@ ActiveAdmin.register User do
   permit_params :email, :password, :password_confirmation, :full_name
 
   scope :all, default: true
-  scope("Active") { |users| users.where(discarded_at: nil) }
+  scope("Active") { |users| users.kept }
   scope("Onboarded") { |users| users.where.not(onboarding_completed_at: nil) }
   scope("Not Onboarded") { |users| users.where(onboarding_completed_at: nil) }
-  scope("Deleted") { |users| users.where.not(discarded_at: nil) }
+  scope("Deleted") { |users| users.discarded }
 
   index do
     selectable_column


### PR DESCRIPTION
## Summary
- use `kept` and `discarded` scopes provided by discard
- apply the `discarded` count scope on admin dashboard

## Testing
- `bundle exec rspec --format doc --color` *(fails: ruby-3.3.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d211c9588832787f0d2029610d5ab