### PR TITLE
Skip password change notification for Google OAuth

### DIFF
--- a/app/models/concerns/user/omniauthable.rb
+++ b/app/models/concerns/user/omniauthable.rb
@@ -20,6 +20,7 @@ module User::Omniauthable
         # reset the password to a random password and skip sending email
         user.password = Devise.friendly_token[0, 20]
         user.skip_confirmation_notification!
+        user.skip_password_change_notification!
         user.save!
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -152,6 +152,7 @@ RSpec.describe User, type: :model do
           google_user = User.from_omniauth(omniauth_data)
 
           assert google_user.confirmed?
+          expect(ActionMailer::Base.deliveries.count).to eq(0)
         end
       end
 


### PR DESCRIPTION
## Summary
- update omniauthable concern to skip password change emails
- ensure Google OAuth does not send any mail when confirming an existing user

## Testing
- `bundle exec rake spec` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed)*

------
https://chatgpt.com/codex/tasks/task_e_686d20f7757c8327925ae923a161d8bd