### PR TITLE
Remove flash message padding

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -13,8 +13,7 @@
 
         %div{class: ('sm:w-5/6 md:w-4/6 mx-auto' if @width == 'narrow')}
           - if flash.any?
-            .pb-8
-              = render FlashMessagesComponent.new(flash)
+            = render FlashMessagesComponent.new(flash)
 
           %main= yield
 


### PR DESCRIPTION
## Summary
- avoid pushing content down by removing `pb-8` padding from the flash message block

## Testing
- `bundle check` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_686d20dc5930832787bda841b610a8a9