### PR TITLE
Add theme color meta tags with light/dark support

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,12 @@ module ApplicationHelper
       icon: [
         {href: "/favicon.ico"},
         {href: "/apple-touch-icon.png", rel: "apple-touch-icon"}
-      ]
+      ],
+      "theme-color": [
+        {content: BROWSER_THEME_COLOR_LIGHT, media: "(prefers-color-scheme: light)"},
+        {content: BROWSER_THEME_COLOR_DARK, media: "(prefers-color-scheme: dark)"}
+      ],
+      "color-scheme": "light dark"
     }
 
     if !Rails.env.production?

--- a/app/views/layouts/components/_head.html.haml
+++ b/app/views/layouts/components/_head.html.haml
@@ -1,6 +1,5 @@
 %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}
 %meta{content: "width=device-width,initial-scale=1", name: "viewport"}
-%meta{content: "#{BROWSER_THEME_COLOR}", name: "theme-color"}
 
 %link{href: asset_path("#{APPLE_TOUCH_ICON_PATH}"), rel: "apple-touch-icon", sizes: "180x180"}
 

--- a/config/initializers/0_constants.rb
+++ b/config/initializers/0_constants.rb
@@ -7,7 +7,8 @@ APP_NAME = "Rapid Rails".freeze
 APP_SLUG = "rapidrails".freeze
 
 APPLE_TOUCH_ICON_PATH = "/apple-touch-icon.png".freeze
-BROWSER_THEME_COLOR = "#000000".freeze
+BROWSER_THEME_COLOR_LIGHT = "#FFFFFF".freeze
+BROWSER_THEME_COLOR_DARK = "#000000".freeze
 
 COMPANY_NAME = "Daniel Paul".freeze
 COMPANY_LOCATION = "London, UK".freeze


### PR DESCRIPTION
## Summary
- add separate constants for light and dark theme colors
- define theme-color and color-scheme meta tags in `default_meta_tags`
- remove hardcoded theme-color tag from head partial

## Testing
- `bundle exec rspec` *(fails: ruby 3.3.0 not installed)*
- `bin/rails test` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d20d1f8f8832797335297b27a0c3f