### PR TITLE
Add Heroku dyno metadata step

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Set config vars:
 - [ ] Set `RAILS_MASTER_KEY` config var to decrypt `credentials.yml.enc` file
 - [ ] Set `HOST` config var to your domain
 - [ ] Set `RAILS_ENV` config var to `production`
+- [ ] Enable dyno metadata for Sentry deploy tagging `heroku labs:enable runtime-dyno-metadata -a <app_name>`
 
 Setup Buildpacks:
 


### PR DESCRIPTION
## Summary
- note that dyno metadata must be enabled for Sentry deployment tagging

## Testing
- `bundle install --path vendor/bundle` *(fails: Your Ruby version is 3.3.8, but your Gemfile specified 3.3.0)*
- `bundle exec rspec` *(fails: command not found because bundle install failed)*

------
https://chatgpt.com/codex/tasks/task_e_686d209925508327acbf435a24c47971