### PR TITLE
Fix spacing on password forms

### DIFF
--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -6,7 +6,7 @@
     
 
 .mt-8.card.card-body
-  = form_for(resource, as: resource_name, url: confirmation_path(resource_name), builder: RapidRailsFormBuilder, html: { method: :post, class: 'space-y-6 -mt-6' }) do |f|
+  = form_for(resource, as: resource_name, url: confirmation_path(resource_name), builder: RapidRailsFormBuilder, html: { method: :post, class: 'space-y-6' }) do |f|
     = render FormErrorsComponent.new(resource)
     
     = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Your email address", value: params[:email] || (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), required: true

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -10,7 +10,7 @@
 
 .mt-8.card
   .card-body
-    = form_for(resource, as: resource_name, url: password_path(resource_name), builder: RapidRailsFormBuilder, html: {method: :put, class: 'space-y-6 -mt-6'}) do |f|
+    = form_for(resource, as: resource_name, url: password_path(resource_name), builder: RapidRailsFormBuilder, html: {method: :put, class: 'space-y-6'}) do |f|
       = render FormErrorsComponent.new(resource)
       = f.hidden_field :reset_password_token
 

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -13,7 +13,7 @@
       Enter the email address associated with your account and we'll send you a link to reset your password.
   
   .card-body
-    = form_for(resource, as: resource_name, url: password_path(resource_name), builder: RapidRailsFormBuilder, html: {method: :post, class: 'space-y-6 -mt-6'}) do |f|
+    = form_for(resource, as: resource_name, url: password_path(resource_name), builder: RapidRailsFormBuilder, html: {method: :post, class: 'space-y-6'}) do |f|
       = render FormErrorsComponent.new(resource)
 
       = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Your email address", autofocus: true


### PR DESCRIPTION
## Summary
- remove negative margin from password reset and confirmation forms

## Testing
- `bundle install` *(fails: Your Ruby version is 3.3.8, but your Gemfile specified 3.3.0)*
- `bundle exec rspec` *(not run due to bundle install failure)*

------
https://chatgpt.com/codex/tasks/task_e_686d2090cf808327b9be70aa2407ea33