### PR TITLE
Fix avatar MIME type validation

### DIFF
--- a/app/models/concerns/user/avatar.rb
+++ b/app/models/concerns/user/avatar.rb
@@ -7,8 +7,8 @@ module User::Avatar
 
       validates :profile_picture,
         content_type: {
-          in: ["image/png", "image/jpg", "image/jpeg"],
-          message: "must be a png, jpg, or jpeg image file"
+          in: ["image/png", "image/jpeg"],
+          message: "must be a png or jpeg image file"
         },
         size: {less_than: 10.megabytes}
     end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -18,7 +18,7 @@
                 .col-span-2
                   = image_tag @user.avatar_url, class:  "rounded-full h-16 w-16 col-span-2"
                 .col-span-8
-                  = f.file_field :profile_picture, accept: "image/png, image/jpg, image/jpeg", hint: "png, jpg or jpeg image formats. Max file size 5MB.", label: {text: "Change Profile Picture"}
+                  = f.file_field :profile_picture, accept: "image/png, image/jpeg", hint: "png or jpeg image formats. Max file size 5MB.", label: {text: "Change Profile Picture"}
            
             = f.text_field :full_name, autocomplete: "name", placeholder: "John Doe", required: true
             


### PR DESCRIPTION
## Summary
- allow only valid `image/png` and `image/jpeg` content types for avatars
- adjust the registration form to advertise the valid types

## Testing
- `bundle exec rspec` *(fails: ActiveRecord::ConnectionNotEstablished)*

------
https://chatgpt.com/codex/tasks/task_e_686d20ad4bf08327bb613622cef0a733