### PR TITLE
Fix avatar URL to return representation URL

### DIFF
--- a/app/models/concerns/user/avatar.rb
+++ b/app/models/concerns/user/avatar.rb
@@ -16,8 +16,10 @@ module User::Avatar
 
   def avatar_url
     if ENABLE_USER_AVATAR_UPLOAD && profile_picture.attached? && profile_picture.variable?
-      # Use ActiveStorage's variant to resize image to 100x100
-      return profile_picture.variant(resize_to_fill: [500, 500]).processed
+      # Use ActiveStorage's variant to resize image to 500x500 and return the URL
+      return Rails.application.routes.url_helpers.url_for(
+        profile_picture.variant(resize_to_fill: [500, 500])
+      )
     end
 
     # Don't share real names. Just initials.


### PR DESCRIPTION
## Summary
- return the representation URL string for the `avatar_url` method

## Testing
- `bundle install` *(fails: Your Ruby version is 3.3.8, but your Gemfile specified 3.3.0)*
- `bundle exec rspec` *(fails: command not found because bundle install failed)*

------
https://chatgpt.com/codex/tasks/task_e_686d20bb8de48327af4a695b107bd385