### PR TITLE
Use ActiveStorage proxy route

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,3 @@
+Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_proxy
+
+# Serve files via proxy so they can be cached by Cloudflare

--- a/docs/active_storage.mdx
+++ b/docs/active_storage.mdx
@@ -25,3 +25,7 @@ Create two buckets:
 Update the secrets on the credentials file.
 
 NOTE: ENABLE_FILE_UPLOAD must be set to true in the constants file for file uploads to work. Also enable the required gems in the Gemfile.
+### Proxy uploads through Rails
+
+To allow Cloudflare to cache uploaded files, we serve Active Storage files using the proxy route. This is configured in `config/initializers/active_storage.rb` by setting `config.active_storage.resolve_model_to_route` to `:rails_storage_proxy`.
+

--- a/docs/active_storage.mdx
+++ b/docs/active_storage.mdx
@@ -19,13 +19,14 @@ Follow the instructions on [this page](https://kirillplatonov.com/posts/activest
 When creating a bucket, pick the location closest to your users & your server. This will help reduce latency.
 
 Create two buckets:
+
 1. Private bucket for file uploads that are accessed with presigned URLs.
 2. Public bucket for the sitemap. (Enable public .r2.dev domain access in settings).
 
 Update the secrets on the credentials file.
 
 NOTE: ENABLE_FILE_UPLOAD must be set to true in the constants file for file uploads to work. Also enable the required gems in the Gemfile.
+
 ### Proxy uploads through Rails
 
 To allow Cloudflare to cache uploaded files, we serve Active Storage files using the proxy route. This is configured in `config/initializers/active_storage.rb` by setting `config.active_storage.resolve_model_to_route` to `:rails_storage_proxy`.
-


### PR DESCRIPTION
## Summary
- configure ActiveStorage to proxy files through the app
- document Cloudflare caching setup

## Testing
- `bin/rails --version` *(fails: Your Ruby version is 3.3.8, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_686d20c31b90832783186cdc22cf3dd2