### PR TITLE
Seed admin user confirmed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ brew services start redis
 - Run `bin/dev` to start the app locally
 - Run `overmind connect web` to connect to the web process logs & run debugger
 - Open `localhost:3000` in your web browser to view the app
-- Open `localhost:3000/admin` to view the admin panel (create an AdminUser record via console).
+- Open `localhost:3000/admin` to view the admin panel. A confirmed AdminUser is seeded in development for immediate access.
 - Open `localhost:3000/rails/mailers` to view mailers preview locally
 - Open `localhost:3000/sidekiq` to view sidekiq dashboard
 - Emails sent in local development are automatically opened in the browser by letter_opener.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,10 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
-AdminUser.create!(email: "admin@example.com", password: "password", password_confirmation: "password") if Rails.env.development?
+if Rails.env.development?
+  admin = AdminUser.find_or_initialize_by(email: "admin@example.com")
+  admin.password = "password"
+  admin.password_confirmation = "password"
+  admin.skip_confirmation! if admin.confirmed_at.blank?
+  admin.save!
+end


### PR DESCRIPTION
## Summary
- confirm AdminUser after seeding a development database
- note the default AdminUser in README

## Testing
- `bundle exec standardrb`
- `bundle exec brakeman -q`
- `bin/rake` *(fails: connection to server on socket `/var/run/postgresql/.s.PGSQL.5432` failed)*
- `bundle exec rspec` *(fails: connection to server on socket `/var/run/postgresql/.s.PGSQL.5432` failed)*

------
https://chatgpt.com/codex/tasks/task_e_686d212367f48327be346765c469d994